### PR TITLE
Add WindowOption and RunWithOptions method to allow for extra configuration

### DIFF
--- a/crt.go
+++ b/crt.go
@@ -68,41 +68,6 @@ type Window struct {
 
 type WindowOption func(window *Window)
 
-// WithWindowTitle sets the window title.
-func WithWindowTitle(title string) WindowOption {
-	return func(window *Window) {
-		ebiten.SetWindowTitle(title)
-	}
-}
-
-// WithScreenFilter enables the screen filter.
-func WithScreenFilter() WindowOption {
-	return func(window *Window) {
-		ebiten.SetScreenFilterEnabled(true)
-	}
-}
-
-// WithoutScreenFilter disables the screen filter.
-func WithoutScreenFilter() WindowOption {
-	return func(window *Window) {
-		ebiten.SetScreenFilterEnabled(true)
-	}
-}
-
-// WithWindowDecoration enables window decorations.
-func WithWindowDecoration() WindowOption {
-	return func(window *Window) {
-		ebiten.SetWindowDecorated(true)
-	}
-}
-
-// WithoutWindowDecoration enables window decorations.
-func WithoutWindowDecoration() WindowOption {
-	return func(window *Window) {
-		ebiten.SetWindowDecorated(false)
-	}
-}
-
 // NewGame creates a new terminal game with the given dimensions and font faces.
 func NewGame(width int, height int, fonts Fonts, tty io.Reader, adapter InputAdapter, defaultBg color.Color) (*Window, error) {
 	if defaultBg == nil {

--- a/crt.go
+++ b/crt.go
@@ -66,6 +66,43 @@ type Window struct {
 	invalidateBuffer bool
 }
 
+type WindowOption func(window *Window)
+
+// WithWindowTitle sets the window title.
+func WithWindowTitle(title string) WindowOption {
+	return func(window *Window) {
+		ebiten.SetWindowTitle(title)
+	}
+}
+
+// WithScreenFilter enables the screen filter.
+func WithScreenFilter() WindowOption {
+	return func(window *Window) {
+		ebiten.SetScreenFilterEnabled(true)
+	}
+}
+
+// WithoutScreenFilter disables the screen filter.
+func WithoutScreenFilter() WindowOption {
+	return func(window *Window) {
+		ebiten.SetScreenFilterEnabled(true)
+	}
+}
+
+// WithWindowDecoration enables window decorations.
+func WithWindowDecoration() WindowOption {
+	return func(window *Window) {
+		ebiten.SetWindowDecorated(true)
+	}
+}
+
+// WithoutWindowDecoration enables window decorations.
+func WithoutWindowDecoration() WindowOption {
+	return func(window *Window) {
+		ebiten.SetWindowDecorated(false)
+	}
+}
+
 // NewGame creates a new terminal game with the given dimensions and font faces.
 func NewGame(width int, height int, fonts Fonts, tty io.Reader, adapter InputAdapter, defaultBg color.Color) (*Window, error) {
 	if defaultBg == nil {
@@ -624,6 +661,20 @@ func (g *Window) Run(title string) error {
 	ebiten.SetScreenFilterEnabled(false)
 	ebiten.SetWindowSize(int(float64(g.cellsWidth*g.cellWidth)/DeviceScale()), int(float64(g.cellsHeight*g.cellHeight)/DeviceScale()))
 	ebiten.SetWindowTitle(title)
+	if err := ebiten.RunGame(g); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Window) RunWithOptions(options ...WindowOption) error {
+	ebiten.SetWindowSize(int(float64(g.cellsWidth*g.cellWidth)/DeviceScale()), int(float64(g.cellsHeight*g.cellHeight)/DeviceScale()))
+
+	for _, opt := range options {
+		opt(g)
+	}
+
 	if err := ebiten.RunGame(g); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi,
I needed to create a window without decorations but using the existing Run() method I wasn't able to specify this.
So I created a WindowOption type that can be passed to a new RunWithOptions method to allow for extra customization of the underlying window. 

This lets the user implement these options and apply them to the window.
The example would become something like this:

```go
package main

import (
	"github.com/BigJk/crt"
	bubbleadapter "github.com/BigJk/crt/bubbletea"
	tea "github.com/charmbracelet/bubbletea"
	"github.com/hajimehoshi/ebiten/v2"
	"image/color"
)

// Some tea.Model ...

// WithoutScreenFilter disables the screen filter.
func WithoutScreenFilter() crt.WindowOption {
	return func(window *crt.Window) {
		ebiten.SetScreenFilterEnabled(false)
	}
}

// WithoutWindowDecoration enables window decorations.
func WithoutWindowDecoration() crt.WindowOption {
	return func(window *crt.Window) {
		ebiten.SetWindowDecorated(false)
	}
}

func main() {
	// Load fonts for normal, bold and italic text styles.
	fonts, err := crt.LoadFaces("./fonts/SomeFont-Regular.ttf", "./fonts/SomeFont-Bold.ttf", "./fonts/SomeFont-Italic.ttf", crt.GetFontDPI(), 16.0)
	if err != nil {
		panic(err)
	}

	// Just pass your tea.Model to the bubbleadapter, and it will render it to the terminal.
	win, _, err := bubbleadapter.Window(1000, 600, fonts, someModel{}, color.Black, tea.WithAltScreen())
	if err != nil {
		panic(err)
	}

	// Start the terminal with the given title.
	if err := win.RunWithOptions(
		WithoutWindowDecoration(),
		WithoutScreenFilter(),
	); err != nil {
		panic(err)
	}
}

```

Thanks for your work on this library